### PR TITLE
adding the part-b troubleshooting

### DIFF
--- a/deploy/adservice.yaml
+++ b/deploy/adservice.yaml
@@ -15,7 +15,8 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/adservice:v0.3.1
+        image: gcr.io/google-samples/microservices-demo/adservice:v0.3.4
+        imagePullPolicy: Always
         ports:
         - containerPort: 9555
         env:

--- a/deploy/cartservice.yaml
+++ b/deploy/cartservice.yaml
@@ -29,12 +29,12 @@ spec:
             cpu: 300m
             memory: 128Mi
         readinessProbe:
-          initialDelaySeconds: 15
+          initialDelaySeconds: 30
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:7070", "-rpc-timeout=5s"]
         livenessProbe:
-          initialDelaySeconds: 15
-          periodSeconds: 10
+          initialDelaySeconds: 30
+          periodSeconds: 20
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:7070", "-rpc-timeout=5s"]
 ---


### PR DESCRIPTION
- Fixed the issue for adservices image 
- Fixed the issue for probe liveness error for carservices - Found on google that it is due to container is getting less time to get ready in live state. 